### PR TITLE
Update: Hotkey mismatches between weight submission and saving

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,15 @@
+
+def normalize_weights(weights_dict: dict[int, float]) -> dict[int, float]:
+    """
+    Normalize weights dictionary so that the sum equals 1.0.
+
+    Args:
+        weights_dict: Dictionary mapping UID to weight value
+    Returns:
+        Normalized weights dictionary with sum = 1.0
+    """
+
+    total = sum(weights_dict.values())
+    if total <= 0:
+        return {}
+    return {uid: w / total for uid, w in weights_dict.items()}


### PR DESCRIPTION
Prevents validators give weights of deregistered miners to replaced ones

- Every WEIGHT_CALC_INTERVAL(1000 block)
  calculate weights for miners, save it as a file

- Every WEIGHT_SET_INTERVAL(360block)
  read saved weights, write to subtensor

- Gaps between weight calculation and submission allow newly registered miners receive weights of deregistered ones.
