### PR TITLE
Fix: Increase max_iter to prevent LBFGS convergence warnings

### DIFF
--- a/model.py
+++ b/model.py
@@ -102,7 +102,7 @@ def _fit_base_logistic(
         C=0.5,
         class_weight="balanced",
         solver=solver,
-        max_iter=100,
+        max_iter=2000,
         tol=1e-3,
         random_state=seed,
     )


### PR DESCRIPTION
**Summary**

This PR increases the maximum number of iterations allowed for the LogisticRegression solver in model.py to ensure the model converges properly during training.

**The Problem**

Validators are frequently encountering the following warning in logs: ConvergenceWarning: lbfgs failed to converge after 100 iteration(s) (status=1): STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT

The default limit of 100 iterations is often insufficient for the LBFGS solver to find the optimal solution for the current dataset complexity. This premature termination can lead to suboptimal model performance and potentially affect salience scores.

**The Solution**

- Updated _fit_base_logistic in model.py.

- Increased max_iter from default (100) to 2000.

**Impact**

This change eliminates the convergence warnings and improves the reliability and accuracy of the weight calculation process by allowing the optimizer enough steps to converge.